### PR TITLE
fix: cvar error in client console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
 
-      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.1
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         with:
           delete_release: true

--- a/scripting/ServerAdvertisements.sp
+++ b/scripting/ServerAdvertisements.sp
@@ -32,7 +32,6 @@ StringMap gGreetedAuthIds;
 
 public void OnPluginStart()
 {
-	CreateConVar("SA_version", PLUGIN_VERSION, "ServerAdvertisements", FCVAR_SPONLY | FCVAR_NOTIFY);
 	AutoExecConfig(true, "ServerAdvertisements");
 
 	RegAdminCmd("sm_SAr", Command_SAr, ADMFLAG_ROOT, "Message reload");


### PR DESCRIPTION
Get ride of console error: ConVarRef SA_version doesn't point to an existing ConVar